### PR TITLE
Add Button Groups

### DIFF
--- a/src/ui/axis-chart/demo/app.jsx
+++ b/src/ui/axis-chart/demo/app.jsx
@@ -6,7 +6,7 @@ import { maxBy, minBy, map, uniqBy } from 'lodash';
 import d3Scale from 'd3-scale';
 
 import { dataGenerator } from '../../../test-utils';
-import { AxisChart } from '../';
+import AxisChart from '../';
 import { MultiLine } from '../../shape';
 import { XAxis, YAxis } from '../../axis';
 

--- a/src/ui/axis-chart/index.js
+++ b/src/ui/axis-chart/index.js
@@ -1,5 +1,1 @@
-import AxisChart from './src/components/axis-chart';
-
-export {
-  AxisChart
-};
+export { default as default } from './src/components/axis-chart';

--- a/src/ui/axis-chart/test/axis-chart.test.js
+++ b/src/ui/axis-chart/test/axis-chart.test.js
@@ -7,7 +7,7 @@ import { shallow } from 'enzyme';
 import { maxBy, minBy, map, uniqBy } from 'lodash';
 
 import { dataGenerator } from '../../../test-utils';
-import { AxisChart } from '../';
+import AxisChart from '../';
 
 chai.use(chaiEnzyme());
 

--- a/src/ui/axis/demo/app.jsx
+++ b/src/ui/axis/demo/app.jsx
@@ -2,7 +2,7 @@ import React from 'react';
 import { render } from 'react-dom';
 import d3Scale from 'd3-scale';
 
-import { Axis } from '../';
+import Axis from '../';
 
 class App extends React.Component {
  render() {

--- a/src/ui/axis/index.js
+++ b/src/ui/axis/index.js
@@ -1,3 +1,3 @@
-export { default as Axis } from './src/components/axis';
+export { default as default } from './src/components/axis';
 export { default as XAxis } from './src/components/xaxis';
 export { default as YAxis } from './src/components/yaxis';

--- a/src/ui/axis/test/axis.test.js
+++ b/src/ui/axis/test/axis.test.js
@@ -4,7 +4,7 @@ import chaiEnzyme from 'chai-enzyme';
 import { shallow } from 'enzyme';
 import d3Scale from 'd3-scale';
 
-import { Axis } from '../';
+import Axis from '../';
 
 chai.use(chaiEnzyme());
 

--- a/src/ui/button/demo/app.jsx
+++ b/src/ui/button/demo/app.jsx
@@ -3,6 +3,7 @@ import React from 'react';
 import { render } from 'react-dom';
 
 import Button from '../src/button';
+import HtmlLabel from '../../html-label';
 
 class App extends React.Component {
   constructor(props) {
@@ -54,12 +55,13 @@ class App extends React.Component {
         <section>
           <h3>A button with a label on a dark background</h3>
           <pre><code>
-  <Button
-    text="Click me!"
-    label="A button"
-    theme="dark"
-    clickHandler={function onClick() { alert('You clicked me!'); }}
-  />
+  <HtmlLabel text="A button " theme="dark">
+    <Button
+      text="Click me!"
+      theme="dark"
+      clickHandler={function onClick() { alert('You clicked me!'); }}
+    />
+  </HtmlLabel>
           </code></pre>
           <div style={
             {
@@ -71,19 +73,25 @@ class App extends React.Component {
               justifyContent: 'center'
             }}
           >
-            <Button
-              text="Click me!"
-              label="A button"
+            <HtmlLabel
+              text="A button "
               theme="dark"
-              clickHandler={function onClick() { alert('You clicked me!'); }}
-            />
+            >
+              <Button
+                text="Click me!"
+                theme="dark"
+                clickHandler={function onClick() { alert('You clicked me!'); }}
+              />
+            </HtmlLabel>
           </div>
         </section>
         <section>
           <h3>A button with a spinner</h3>
           <pre><code>
   <Button
-    showSpinner
+    text="Delete all files"
+    showSpinner={this.state.isLoading}
+    clickHandler={this.showIsLoading}
   />
           </code></pre>
           <div>

--- a/src/ui/button/demo/app.jsx
+++ b/src/ui/button/demo/app.jsx
@@ -18,7 +18,6 @@ class App extends React.Component {
     });
   }
 
-
   render() {
     return (
       <div>
@@ -28,13 +27,13 @@ class App extends React.Component {
   <Button
     text="Click me!"
     clickHandler={function onClick() { alert('You clicked me!'); }}
-    classes={['an', 'extra', 'class']}
+    className={['an', 'extra', 'class']}
   />
           </code></pre>
           <Button
             text="Click me!"
             clickHandler={function onClick() { alert('You clicked me!'); }}
-            classes={['an', 'extra', 'class']}
+            className={['an', 'extra', 'class']}
           />
         </section>
         <section>

--- a/src/ui/button/index.js
+++ b/src/ui/button/index.js
@@ -1,1 +1,1 @@
-export { default } from './src/button';
+export { default as default } from './src/button';

--- a/src/ui/button/src/button.jsx
+++ b/src/ui/button/src/button.jsx
@@ -2,7 +2,6 @@ import React, { PropTypes } from 'react';
 import classNames from 'classnames';
 
 import styles from './button.css';
-import HtmlLabel from '../../html-label';
 import Spinner from '../../spinner';
 
 const propTypes = {
@@ -11,9 +10,6 @@ const propTypes = {
 
   /* color scheme of component; see button.css */
   theme: PropTypes.oneOf(['dark', 'light']),
-
-  /* a label to include for the button */
-  label: PropTypes.string,
 
   id: PropTypes.string,
 
@@ -54,16 +50,14 @@ const Button = (props) => {
     clickHandler,
     text,
     showSpinner,
-    label,
     icon,
     theme
   } = props;
 
-  const button = (
+  return (
     <button
       className={classNames({
         [styles[props.theme]]: true,
-        [styles.labeled]: props.label,
         [styles.disabled]: disabled
       }, ...classes)}
       id={id}
@@ -75,17 +69,6 @@ const Button = (props) => {
       {getButtonContent(showSpinner, icon)}
       {text}
     </button>
-  );
-
-  if (!label) return button;
-  return (
-    <HtmlLabel
-      text={label}
-      theme={theme}
-      htmlFor={id}
-    >
-      {button}
-    </HtmlLabel>
   );
 };
 

--- a/src/ui/button/src/button.jsx
+++ b/src/ui/button/src/button.jsx
@@ -1,4 +1,5 @@
 import React, { PropTypes } from 'react';
+
 import classNames from 'classnames';
 
 import styles from './button.css';
@@ -6,73 +7,63 @@ import Spinner from '../../spinner';
 
 const propTypes = {
   /* array of classes to add to button */
-  classes: PropTypes.array,
+  className: PropTypes.oneOfType([
+    PropTypes.string,
+    PropTypes.object,
+    PropTypes.array
+  ]),
 
-  /* color scheme of component; see button.css */
-  theme: PropTypes.oneOf(['dark', 'light']),
+  clickHandler: PropTypes.func,
+
+  disabled: PropTypes.bool,
+
+  /* path to image to render within button tag */
+  icon: PropTypes.string,
 
   id: PropTypes.string,
 
   name: PropTypes.string,
 
-  disabled: PropTypes.bool,
+  /* if true, will contain spinner */
+  showSpinner: PropTypes.bool,
 
   /* text to render within button tag */
   text: PropTypes.string,
 
-  /* path to image to render within button tag */
-  icon: PropTypes.string,
-
-  /* if true, will contain spinner */
-  showSpinner: PropTypes.bool,
-
-  clickHandler: PropTypes.func
+  /* color scheme of component; see button.css */
+  theme: PropTypes.oneOf(['dark', 'light'])
 };
 
 const defaultProps = {
-  classes: [],
-  disabled: false,
-  theme: 'light'
+  disabled: false
 };
 
-const getButtonContent = (showSpinner, iconPath) => {
+const getContent = (showSpinner, iconPath) => {
   if (showSpinner) return <Spinner size="small" />;
   if (iconPath) return <img src={iconPath} />;
   return null;
 };
 
 const Button = (props) => {
-  const {
-    disabled,
-    classes,
-    id,
-    name,
-    clickHandler,
-    text,
-    showSpinner,
-    icon,
-    theme
-  } = props;
-
   return (
     <button
-      className={classNames({
-        [styles[props.theme]]: true,
-        [styles.disabled]: disabled
-      }, ...classes)}
-      id={id}
+      className={classNames(props.className, styles[props.theme], {
+        [styles.disabled]: props.disabled
+      })}
+      disabled={props.disabled}
+      id={props.id}
+      name={props.name}
+      onClick={props.clickHandler}
       type="button"
-      name={name}
-      disabled={disabled}
-      onClick={clickHandler}
     >
-      {getButtonContent(showSpinner, icon)}
-      {text}
+      {getContent(props.showSpinner, props.icon)}
+      {props.text}
     </button>
   );
 };
 
 Button.propTypes = propTypes;
+
 Button.defaultProps = defaultProps;
 
 export default Button;

--- a/src/ui/button/test/button.test.js
+++ b/src/ui/button/test/button.test.js
@@ -24,12 +24,6 @@ describe('<Button/>', () => {
     });
   });
 
-  it('renders itself within a label', () => {
-    const wrapper = shallow(<Button label="A label" />);
-    expect(wrapper).to.have.tagName('label');
-    expect(wrapper).to.have.exactly(1).descendants('button');
-  });
-
   it('shows a spinner when showSpinner is true', () => {
     const wrapper = shallow(<Button showSpinner />);
     expect(wrapper).to.contain(<Spinner size="small" />);

--- a/src/ui/button/test/button.test.js
+++ b/src/ui/button/test/button.test.js
@@ -1,4 +1,5 @@
 import React from 'react';
+
 import chai, { expect } from 'chai';
 import chaiEnzyme from 'chai-enzyme';
 import { shallow } from 'enzyme';
@@ -8,7 +9,7 @@ import Spinner from '../../spinner';
 
 chai.use(chaiEnzyme());
 
-describe('<Button/>', () => {
+describe('<Button />', () => {
   it('renders a button', () => {
     const wrapper = shallow(<Button />);
     expect(wrapper).to.have.length(1);
@@ -17,7 +18,7 @@ describe('<Button/>', () => {
 
   it('spreads a list of classes into the button', () => {
     const classes = ['foo', 'bar', 'baz'];
-    const wrapper = shallow(<Button classes={classes} />);
+    const wrapper = shallow(<Button className={classes} />);
 
     classes.forEach((expectedClass) => {
       expect(wrapper).to.have.className(expectedClass);

--- a/src/ui/group/demo/app.jsx
+++ b/src/ui/group/demo/app.jsx
@@ -1,6 +1,8 @@
 import React from 'react';
 import { render } from 'react-dom';
 
+import { concat } from 'lodash';
+
 import Group from '../';
 import { Option } from '../';
 
@@ -11,8 +13,6 @@ const data = [
   { name: 'both', value: '3' }
 ];
 
-const disabledItems = ['3'];
-
 class App extends React.Component {
   constructor(props) {
     super(props);
@@ -20,10 +20,15 @@ class App extends React.Component {
     this.state = { selectedItems: '1', disabledItems: '3' };
 
     this.setSelection = this.setSelection.bind(this);
+    this.isDisabled = this.isDisabled.bind(this);
   }
 
   setSelection({ value }) {
     this.setState({ selectedItems: value });
+  }
+
+  isDisabled(value) {
+    return concat([], this.state.disabledItems).includes(value);
   }
 
   render() {
@@ -39,7 +44,7 @@ class App extends React.Component {
                 text={datum.name}
                 value={datum.value}
                 selected={this.state.selectedItems === datum.value}
-                disabled={((value) => { return disabledItems.includes(value); })(datum.value)}
+                disabled={this.isDisabled(datum.value)}
               />
             );
           })

--- a/src/ui/group/demo/app.jsx
+++ b/src/ui/group/demo/app.jsx
@@ -1,0 +1,52 @@
+import React from 'react';
+import { render } from 'react-dom';
+
+import Group from '../';
+import { Option } from '../';
+
+
+const data = [
+  { name: 'males', value: '1' },
+  { name: 'females', value: '2' },
+  { name: 'both', value: '3' }
+];
+
+const disabledItems = ['3'];
+
+class App extends React.Component {
+  constructor(props) {
+    super(props);
+
+    this.state = { selectedItems: '1', disabledItems: '3' };
+
+    this.setSelection = this.setSelection.bind(this);
+  }
+
+  setSelection({ value }) {
+    this.setState({ selectedItems: value });
+  }
+
+  render() {
+    return (
+      <Group
+        clickHandler={this.setSelection}
+      >
+        {
+          data.map((datum, index) => {
+            return (
+              <Option
+                key={index}
+                text={datum.name}
+                value={datum.value}
+                selected={this.state.selectedItems === datum.value}
+                disabled={((value) => { return disabledItems.includes(value); })(datum.value)}
+              />
+            );
+          })
+        }
+      </Group>
+    );
+  }
+}
+
+render(<App />, document.getElementById('app'));

--- a/src/ui/group/demo/html-pre-tag-loader.js
+++ b/src/ui/group/demo/html-pre-tag-loader.js
@@ -1,0 +1,23 @@
+'use strict';
+
+var blockLoader = require('block-loader');
+
+var options = {
+  start: "<pre><code>",
+  end: "</code></pre>",
+  process: function fixPreBlocks(pre) {
+    var replaced = pre
+      .replace(options.start,'')   // first, remove the start/end delimiters, then:
+      .replace(options.end,'')     //
+      .replace(/&/g,'&amp;')       // 1. use html entity equivalent,
+      .replace(/</g,'&lt;')        // 2. use html entity equivalent,
+      .replace(/>/g,'&gt;')        // 3. use html entity equivalent,
+      .replace(/([{}])/g,"{'$1'}") // 4. JSX-safify curly braces,
+      .replace(/\n/g,"{'\\n'}");   // 5. and preserve line endings, thanks.
+
+    // done! return with the delimiters put back in place
+    return options.start + replaced + options.end
+  }
+};
+
+module.exports = blockLoader(options);

--- a/src/ui/group/demo/index.html
+++ b/src/ui/group/demo/index.html
@@ -1,0 +1,29 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <title>Symbol Demo</title>
+  <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/normalize/3.0.3/normalize.min.css">
+  <style>
+    html, body {
+      box-sizing: border-box;
+    }
+
+    body {
+      width: 100%;
+      height: 100%;
+    }
+
+    #app {
+      display: flex;
+      justify-content: center;
+      align-items: center;
+    }
+  </style>
+</head>
+<body>
+  <main id="app"></main>
+  <script src="../../../../node_modules/babel-polyfill/dist/polyfill.js"></script>
+  <script src="bundle.js"></script>
+</body>
+</html>

--- a/src/ui/group/demo/index.html
+++ b/src/ui/group/demo/index.html
@@ -2,7 +2,7 @@
 <html lang="en">
 <head>
   <meta charset="UTF-8">
-  <title>Symbol Demo</title>
+  <title>Group Demo</title>
   <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/normalize/3.0.3/normalize.min.css">
   <style>
     html, body {

--- a/src/ui/group/demo/index.html
+++ b/src/ui/group/demo/index.html
@@ -19,11 +19,59 @@
       justify-content: center;
       align-items: center;
     }
+
+    section {
+      margin-bottom: 25px;
+      padding-bottom: 10px;
+      border-bottom: 1px solid black;
+      display: flex;
+      flex-direction: column;
+      justify-content: center;
+      align-items: center;
+    }
+
+    pre {
+      background-color: cornsilk;
+    }
   </style>
 </head>
 <body>
-  <main id="app"></main>
-  <script src="../../../../node_modules/babel-polyfill/dist/polyfill.js"></script>
-  <script src="bundle.js"></script>
+<div>
+  <section>
+    <pre>
+      <code>
+  const data = [
+    { name: 'males', value: '1' },
+    { name: 'females', value: '2' },
+    { name: 'both', value: '3' }
+  ];
+
+  const isDisabled = (value) =&gt; {
+    return disabledItems.includes(value);
+  };
+
+  &lt;Group clickHandler={this.setSelection}&gt;
+    {
+      data.map((datum, index) =&gt; {
+        return (
+          &lt;Option
+            key={index}
+            text={datum.name}
+            value={datum.value}
+            selected={this.state.selectedItems === datum.value}
+            disabled={isDisabled(datum.value)}
+          /&gt;
+        );
+      })
+    }
+  &lt;/Group&gt;
+      </code>
+    </pre>
+    <main id="app"></main>
+  </section>
+</div>
+
+<script src="../../../../node_modules/babel-polyfill/dist/polyfill.js"></script>
+<script src="bundle.js"></script>
 </body>
 </html>

--- a/src/ui/group/demo/webpack.config.js
+++ b/src/ui/group/demo/webpack.config.js
@@ -1,0 +1,33 @@
+'use strict';
+
+var path = require('path');
+var autoprefixer = require('autoprefixer');
+
+module.exports = {
+  devtool: 'source-map',
+  context: __dirname,
+  entry: './app',
+  output: {
+    path: __dirname,
+    filename: 'bundle.js'
+  },
+  module: {
+    loaders: [
+      {
+        test: /\.jsx?$/,
+        exclude: 'node-modules/',
+        loaders: ['babel', __dirname + '/html-pre-tag-loader']
+      },
+      {
+        test: /\.css$/,
+        loader: 'style!css-loader?modules&importLoaders=1&localIdentName=[name]__[local]___[hash:base64:5]!postcss-loader'
+      },
+    ]
+  },
+  postcss: [autoprefixer],
+  resolve: {
+    extensions: ['', '.js', '.jsx']
+  },
+  stats: false,
+  progress: true
+};

--- a/src/ui/group/index.js
+++ b/src/ui/group/index.js
@@ -1,0 +1,2 @@
+export { default as default } from './src/group';
+export { default as Option } from './src/option';

--- a/src/ui/group/src/group.css
+++ b/src/ui/group/src/group.css
@@ -1,0 +1,47 @@
+.common {
+  border: 1px solid #aaaaaa;
+  height: 21px;
+  padding: 0 10px;
+  color: rgba(69, 69, 69, 0.6);
+  background-color: #fafafa;
+  display: inline-flex;
+}
+
+.common:focus {
+  outline: none;
+}
+
+.common:disabled,
+.disabled {
+  background-color: white;
+  color: rgba(204, 204, 204, 1);
+}
+
+.active:not(:disabled),
+.common:active:not(:disabled),
+.group > .selected {
+  background-color: #f5f5f5;
+  color: #27ae60;
+}
+
+.dark {
+  composes: common;
+}
+
+.light {
+  composes: common;
+}
+
+.group > *:first-child {
+  border-bottom-left-radius: 4px;
+  border-top-left-radius: 4px;
+  border-right-width: 1px;
+}
+
+.group > *:last-child {
+  border-bottom-right-radius: 4px;
+  border-top-right-radius: 4px;
+}
+
+.group > *:not(:first-child):not(:last-child) {
+}

--- a/src/ui/group/src/group.jsx
+++ b/src/ui/group/src/group.jsx
@@ -1,0 +1,76 @@
+import React, { PropTypes } from 'react';
+
+import classNames from 'classnames';
+
+import styles from './group.css';
+
+
+const propTypes = {
+  children: PropTypes.oneOfType([
+    PropTypes.arrayOf(PropTypes.node),
+    PropTypes.node
+  ]).isRequired,
+
+  className: PropTypes.oneOfType([
+    PropTypes.string,
+    PropTypes.object,
+    PropTypes.array
+  ]),
+
+  /* function with following signature: function({ value }) */
+  clickHandler: PropTypes.func,
+
+  disabledItems: PropTypes.oneOfType([
+    PropTypes.arrayOf(PropTypes.number),
+    PropTypes.arrayOf(PropTypes.string),
+    PropTypes.number,
+    PropTypes.string
+  ]),
+
+  hoverHandler: PropTypes.func,
+
+  selectedItems: PropTypes.oneOfType([
+    PropTypes.arrayOf(PropTypes.number),
+    PropTypes.arrayOf(PropTypes.string),
+    PropTypes.number,
+    PropTypes.string
+  ]),
+
+  theme: PropTypes.oneOf(['dark', 'light', 'common'])
+};
+
+const defaultProps = {
+  theme: 'common'
+};
+
+
+const Group = (props) => {
+  const { children, className, theme } = props;
+
+  const wrappedClickHandler = (wrappedProps) => {
+    return () => {
+      props.clickHandler(wrappedProps);
+    };
+  };
+
+  return (
+    <div className={classNames(className, styles.group)}>
+      {
+        React.Children.map(children, (child) => {
+          const childProps = {
+            className: classNames(styles.option, child.props.className, styles[theme], className),
+            clickHandler: wrappedClickHandler({ value: child.props.value })
+          };
+
+          return React.cloneElement(child, childProps);
+        })
+      }
+    </div>
+  );
+};
+
+Group.propTypes = propTypes;
+
+Group.defaultProps = defaultProps;
+
+export default Group;

--- a/src/ui/group/src/option.jsx
+++ b/src/ui/group/src/option.jsx
@@ -1,0 +1,61 @@
+import React, { PropTypes } from 'react';
+
+import classNames from 'classnames';
+
+import Button from '../../button';
+
+import styles from './group.css';
+
+const propTypes = {
+  className: PropTypes.oneOfType([
+    PropTypes.string,
+    PropTypes.object,
+    PropTypes.array
+  ]),
+
+  clickHandler: PropTypes.func,
+
+  /* apply disabled class styling */
+  disabled: PropTypes.bool,
+
+  hoverHandler: PropTypes.func,
+
+  /* path to image to render within label tag */
+  icon: PropTypes.string,
+
+  /* apply selected class styling */
+  selected: PropTypes.bool,
+
+  /* text to render within label tag */
+  text: PropTypes.string,
+
+  /* react element to be wrapped by this option */
+  type: PropTypes.any
+};
+
+const defaultProps = {
+  type: Button
+};
+
+const Option = (props) => {
+  return React.createElement(
+    props.type,
+    {
+      className: classNames(props.className, {
+        [styles.disabled]: props.disabled,
+        [styles.selected]: props.selected
+      }),
+      clickHandler: props.clickHandler,
+      disabled: props.disabled,
+      hoverHandler: props.hoverHandler,
+      icon: props.icon,
+      text: props.text
+    }
+  );
+};
+
+Option.propTypes = propTypes;
+
+Option.defaultProps = defaultProps;
+
+export default Option;

--- a/src/ui/group/test/group.test.js
+++ b/src/ui/group/test/group.test.js
@@ -1,0 +1,23 @@
+import React from 'react';
+
+import chai, { expect } from 'chai';
+import chaiEnzyme from 'chai-enzyme';
+import { shallow } from 'enzyme';
+
+import Group, { Option } from '../';
+
+chai.use(chaiEnzyme());
+
+describe('<Group />', () => {
+  it('renders options as buttons', () => {
+    const wrapper = shallow(
+      <Group>
+        <Option key={1} text="One" selected />
+        <Option key={2} text="Two" />
+        <Option key={3} text="Three" disabled />
+      </Group>
+    );
+
+    expect(wrapper).to.have.exactly(3).descendants('Option');
+  });
+});

--- a/src/ui/group/test/option.test.js
+++ b/src/ui/group/test/option.test.js
@@ -1,0 +1,17 @@
+import React from 'react';
+
+import chai, { expect } from 'chai';
+import chaiEnzyme from 'chai-enzyme';
+import { shallow } from 'enzyme';
+
+import { Option } from '../';
+
+chai.use(chaiEnzyme());
+
+describe('<Option />', () => {
+  it('renders a button by default', () => {
+    const wrapper = shallow(<Option key={1} text="One" value="1" />);
+
+    expect(wrapper).to.have.exactly(1).descendants('Button');
+  });
+});

--- a/src/ui/html-label/index.js
+++ b/src/ui/html-label/index.js
@@ -1,1 +1,1 @@
-export { default } from './src/html-label';
+export { default as default } from './src/html-label';

--- a/src/ui/html-label/src/html-label.jsx
+++ b/src/ui/html-label/src/html-label.jsx
@@ -1,23 +1,45 @@
 import React, { PropTypes } from 'react';
+
 import classNames from 'classnames';
 
 import styles from './html-label.css';
 
 const propTypes = {
-  text: PropTypes.string.isRequired,
-  children: PropTypes.element.isRequired,
-  theme: PropTypes.string,
-  htmlFor: PropTypes.string
+  children: PropTypes.element,
+
+  /* array of classes to add to label */
+  className: PropTypes.oneOfType([
+    PropTypes.string,
+    PropTypes.object,
+    PropTypes.array
+  ]),
+
+  clickHandler: PropTypes.func,
+
+  hoverHandler: PropTypes.func,
+
+  /* ID of a labelable form-related element */
+  htmlFor: PropTypes.string,
+
+  /* path to image to render within label tag */
+  icon: PropTypes.string,
+
+  /* text to render within label tag */
+  text: PropTypes.string,
+
+  /* color scheme of component; see html-label.css */
+  theme: PropTypes.string
 };
 
 const HtmlLabel = (props) => {
   return (
     <label
-      className={classNames({
-        [styles[props.theme]]: true
-      })}
+      className={classNames(styles[props.theme], props.className)}
       htmlFor={props.htmlFor}
+      onClick={props.clickHandler}
+      onMouseOver={props.hoverHandler}
     >
+      {((path) => { return path ? <img src={path} /> : null; })(props.icon)}
       {props.text}
       {props.children}
     </label>

--- a/src/ui/html-label/test/html-label.test.js
+++ b/src/ui/html-label/test/html-label.test.js
@@ -20,4 +20,10 @@ describe('<HtmlLabel/>', () => {
     const wrapper = shallow(<HtmlLabel text="A label"><input /></HtmlLabel>);
     expect(wrapper).to.have.exactly(1).descendants('input');
   });
+
+  it('displays an icon and text', () => {
+    const wrapper = shallow(<HtmlLabel icon="image.png" text="A text" />);
+    expect(wrapper).to.have.exactly(1).descendants('img')
+      .and.to.have.text('A text');
+  });
 });

--- a/src/ui/range-slider/src/index.js
+++ b/src/ui/range-slider/src/index.js
@@ -1,3 +1,1 @@
-import RangeSlider from './components/range-slider';
-
-export default RangeSlider;
+export { default as default } from './components/range-slider';

--- a/src/ui/shape/demo-scatter-plot/app.jsx
+++ b/src/ui/shape/demo-scatter-plot/app.jsx
@@ -6,7 +6,7 @@ import d3Scale from 'd3-scale';
 import { maxBy, minBy, map, uniqBy } from 'lodash';
 
 import { dataGenerator } from '../../../test-utils';
-import { AxisChart } from '../../axis-chart';
+import AxisChart from '../../axis-chart';
 import { ScatterPlot } from '../';
 
 

--- a/src/ui/shape/demo-symbol/app.jsx
+++ b/src/ui/shape/demo-symbol/app.jsx
@@ -5,7 +5,7 @@ import { maxBy, minBy, map, uniqBy } from 'lodash';
 
 import d3Scale from 'd3-scale';
 
-import { AxisChart } from '../../axis-chart';
+import AxisChart from '../../axis-chart';
 import { Symbol, SYMBOL_TYPES } from '../';
 
 

--- a/src/ui/shape/index.js
+++ b/src/ui/shape/index.js
@@ -1,14 +1,5 @@
-import Line from './src/components/line';
-import MultiLine from './src/components/multi-line';
-import Area from './src/components/area';
-import Symbol, { SYMBOL_TYPES } from './src/components/symbol';
-import ScatterPlot from './src/components/scatter-plot';
-
-export {
-  Line,
-  MultiLine,
-  Area,
-  ScatterPlot,
-  Symbol,
-  SYMBOL_TYPES
-};
+export { default as Area } from './src/components/area';
+export { default as Line } from './src/components/line';
+export { default as MultiLine } from './src/components/multi-line';
+export { default as ScatterPlot } from './src/components/scatter-plot';
+export { default as Symbol, SYMBOL_TYPES } from './src/components/symbol';

--- a/src/ui/spinner/index.js
+++ b/src/ui/spinner/index.js
@@ -1,1 +1,1 @@
-export { default } from './src/spinner';
+export { default as default } from './src/spinner';

--- a/src/utils/index.js
+++ b/src/utils/index.js
@@ -1,5 +1,1 @@
-import * as Domain from './domain';
-
-export default {
-  Domain
-};
+export * from './domain';


### PR DESCRIPTION
This branch cleans up `<Button>` and `<HtmlLabel>` a bit by attempting to standardize the props interface, and adds grouping functionality through `<Group>`.
`<Group>` will contain `<Option>` elements, which by default render `<Button>`s and inherit style from the `<Group>`.